### PR TITLE
[NR-92182] ANRMonitor memory allocation

### DIFF
--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ANRMonitor.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ANRMonitor.kt
@@ -34,10 +34,9 @@ open class ANRMonitor {
     val anrMonitorRunner = Runnable {
         monitorThread.start()
 
+        val runner = WaitableRunner()
         while (!Thread.interrupted()) {
             try {
-                val runner = WaitableRunner()
-
                 synchronized(runner) {
                     if (!handler.post(runner)) {
                         // post returns false on failure, usually because the


### PR DESCRIPTION
Ticket link [here](https://issues.newrelic.com/browse/NR-92182)
Fix: Initialize waitableRunner outside the loop to prevent memory leak
Need a release to make it available for clients