### PR TITLE
[NR-247784] Strip final SO to reduce artifact size

### DIFF
--- a/agent-ndk/build.gradle
+++ b/agent-ndk/build.gradle
@@ -48,7 +48,7 @@ android {
                 targets "agent-ndk", "agent-ndk-test"
 
                 // Passes optional arguments to CMake.
-                arguments "-DCMAKE_BUILD_TYPE=Debug"
+                arguments "-DCMAKE_BUILD_TYPE=Release"
             }
         }
 
@@ -77,7 +77,7 @@ android {
     }
 
     packagingOptions {
-        doNotStrip '**.so'
+        doNotStrip '**/debug/**/*.so'
     }
 
     compileOptions {


### PR DESCRIPTION
Build now produces C/C++ release configuration. AGP will strip symbols from all output except debug variants.

agent-ndk/build/outputs/aar/agent-ndk-release.aar: 
* Prior size: 5710260
* Current Size: 1136199

Additional size savings are possible if we only build 64-bit ABIs (arm64-v8a and x86_64)