### PR TITLE
[NR-274896] Resolve NDK leaks and crashes

### DIFF
--- a/agent-ndk/src/main/cpp/agent-ndk.cpp
+++ b/agent-ndk/src/main/cpp/agent-ndk.cpp
@@ -115,6 +115,7 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_dumpStack(JNIEnv *env, jobject thiz
         delete[] buffer;
         return result;
     }
+    delete[] buffer;
 
     return nullptr;
 }

--- a/agent-ndk/src/main/cpp/agent-ndk.cpp
+++ b/agent-ndk/src/main/cpp/agent-ndk.cpp
@@ -72,7 +72,7 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStart(JNIEnv *env, jobject th
         if (!anr_handler_initialize()) {
             _LOGE("Error: Failed to initialize ANR detection!");
         } else {
-            _LOGD("ANR handler installed");
+            _LOGD("Native ANR handler installed");
         }
     }
 

--- a/agent-ndk/src/main/cpp/anr-handler.cpp
+++ b/agent-ndk/src/main/cpp/anr-handler.cpp
@@ -84,7 +84,7 @@ void anr_interceptor(__unused int signo, siginfo_t *_siginfo, void *ucontext) {
         const ucontext_t *_ucontext = static_cast<const ucontext_t *>(ucontext);
 
         if (collect_backtrace(reportBuffer, BACKTRACE_SZ_MAX, _siginfo, _ucontext)) {
-            serializer::from_anr(reportBuffer, std::strlen(reportBuffer));
+            serializer::from_anr(reportBuffer, BACKTRACE_SZ_MAX);
         }
     }
 
@@ -179,12 +179,12 @@ bool anr_handler_initialize() {
 
     // detect the Android runtime's ANR signal handler
     if (!detect_android_anr_handler()) {
-        _LOGE("Failed to detect Google ANR monitor thread. ANR report will not be sent to Google.");
+        _LOGE("Failed to detect the Android ANR monitor thread. Native ANR reports will not be sent to New Relic.");
     }
 
     // Start a watchdog thread
     if (pthread_create(&watchdog_thread, nullptr, anr_monitor_thread, nullptr) != 0) {
-        _LOGE("Could not create ANR watchdog thread. ANR reports will not be collected.");
+        _LOGE("Could not create an ANR watchdog thread. ANR reports will not be collected.");
         return false;
     }
 

--- a/agent-ndk/src/main/cpp/backtrace.cpp
+++ b/agent-ndk/src/main/cpp/backtrace.cpp
@@ -37,7 +37,7 @@ void collect_thread_info(int tid, threadinfo_t &threadinfo) {
             token = strtok_r(nullptr, ")", &ppos);
             if (token) {
                 if (std::sscanf(token, "(%[A-Za-z0-9 _.:-])", value) == 1) {
-                    std::strncpy(threadinfo.thread_name, value, sizeof(threadinfo.thread_name));
+                    std::strncpy(threadinfo.thread_name, value, sizeof(threadinfo.thread_name) - 1);
                 }
             }
             token = strtok_r(nullptr, delim, &ppos);
@@ -70,7 +70,7 @@ void collect_thread_info(int tid, threadinfo_t &threadinfo) {
                         rstate = "PARKED";
                         break;
                 };  // switch
-                std::strncpy(threadinfo.thread_state, rstate, sizeof(threadinfo.thread_state));
+                std::strncpy(threadinfo.thread_state, rstate, sizeof(threadinfo.thread_state) - 1);
             }
             token = strtok_r(nullptr, delim, &ppos);    // skip ppid
             token = strtok_r(nullptr, delim, &ppos);    // skip pgrp
@@ -149,10 +149,10 @@ bool collect_backtrace(char *backtrace_buffer,
     // unwind the current thread's stacktrace asap
     unwind_backtrace(backtrace.state);
 
-    std::strncpy(backtrace.arch, get_arch(), sizeof(backtrace.arch));
+    std::strncpy(backtrace.arch, get_arch(), sizeof(backtrace.arch) - 1);
     std::strncpy(backtrace.description,
                  sigutils::get_signal_description(siginfo->si_signo, siginfo->si_code),
-                 sizeof(backtrace.description));
+                 sizeof(backtrace.description) - 1);
 
     backtrace.timestamp = time(0L);
     backtrace.uid = getuid();

--- a/agent-ndk/src/main/cpp/include/agent-ndk.h
+++ b/agent-ndk/src/main/cpp/include/agent-ndk.h
@@ -45,4 +45,8 @@ bool collect_backtrace(char *, size_t, const siginfo_t *, const ucontext_t *);
 #define  _LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,   TAG, __VA_ARGS__)
 #define  _LOGI(...)  __android_log_print(ANDROID_LOG_INFO,    TAG, __VA_ARGS__)
 
+#include <errno.h>
+#include <string.h>
+#define  _LOGE_POSIX(msg)  __android_log_print(ANDROID_LOG_INFO, TAG, "%s: %s (errno %d - %s)", __PRETTY_FUNCTION__, msg, errno, std::strerror(errno))
+
 #endif // _AGENT_NDK_AGENT_NDK_H

--- a/agent-ndk/src/main/cpp/jni/native-context.cpp
+++ b/agent-ndk/src/main/cpp/jni/native-context.cpp
@@ -51,7 +51,7 @@ namespace jni {
                                                                     static_cast<jstring>(pathObject));
 
             std::strncpy(native_context.reportPathAbsolute, reportsPath,
-                         sizeof(native_context.reportPathAbsolute));
+                         sizeof(native_context.reportPathAbsolute) - 1);
 
 
             // copy the session ID field
@@ -62,7 +62,7 @@ namespace jni {
             jobject fieldObject = jni::env_get_object_field(env, managedContext, fieldId);
             const char *sessionId = jni::env_get_string_UTF_chars(env,
                                                                   static_cast<jstring>(fieldObject));
-            std::strncpy(native_context.sessionId, sessionId, sizeof(native_context.sessionId));
+            std::strncpy(native_context.sessionId, sessionId, sizeof(native_context.sessionId) - 1);
 
             // copy the build Id field
             fieldId = jni::env_get_fieldid(env,
@@ -72,7 +72,7 @@ namespace jni {
             fieldObject = jni::env_get_object_field(env, managedContext, fieldId);
             const char *buildId = jni::env_get_string_UTF_chars(env,
                                                                 static_cast<jstring>(fieldObject));
-            std::strncpy(native_context.buildId, buildId, sizeof(native_context.buildId));
+            std::strncpy(native_context.buildId, buildId, sizeof(native_context.buildId) - 1);
 
             // copy the anr monitor field
 
@@ -81,10 +81,7 @@ namespace jni {
                                            "anrMonitor",
                                            "Z");
             jboolean anrMonitorEnabled = jni::env_get_boolean_field(env, managedContext, fieldId);
-            _LOGD("anrMonitorEnabled Value for Native %d", anrMonitorEnabled);
-
             native_context.anrMonitorEnabled = anrMonitorEnabled;
-
         }
 
         return instance;
@@ -94,19 +91,28 @@ namespace jni {
      * Release and reset any global JNI resources
      */
     void release_native_context(JNIEnv *env, native_context_t &native_context) {
-        pthread_mutex_lock(&lock);
-        if (native_context.initialized) {
-            release_delegate(env, native_context);
+        if (0 == pthread_mutex_lock(&lock)) {
+            if (native_context.initialized) {
+                release_delegate(env, native_context);
 
-            pthread_mutex_unlock(&lock);
-            pthread_mutex_destroy(&lock);
+                if (0 != pthread_mutex_unlock(&lock)) {
+                    _LOGE_POSIX("pthread_mutex_unlock()");
+                }
+                if (0 != pthread_mutex_destroy(&lock)) {
+                    _LOGE_POSIX("pthread_mutex_destroy()");
+                }
 
-            lock = PTHREAD_MUTEX_INITIALIZER;
-            native_context.initialized = false;
+                lock = PTHREAD_MUTEX_INITIALIZER;
+                native_context.initialized = false;
 
-            return;
+                return;
+            }
+            if (0 != pthread_mutex_unlock(&lock)) {
+                _LOGE_POSIX("pthread_mutex_unlock()");
+            }
+        } else {
+            _LOGE_POSIX("pthread_mutex_lock()");
         }
-        pthread_mutex_unlock(&lock);
     }
 
 }   // namespace jni

--- a/agent-ndk/src/main/cpp/serializer.cpp
+++ b/agent-ndk/src/main/cpp/serializer.cpp
@@ -22,19 +22,17 @@ namespace serializer {
 
     void from_crash(const char *buffer, size_t buffsz) {
         to_storage("crash-", buffer, buffsz);
-        // Crashes are best left in storage and processed
-        // on the next app launch
+        // Crashes are left in storage and processed on the next app launch
     }
 
     void from_exception(const char *buffer, size_t buffsz) {
         to_storage("ex-", buffer, buffsz);
-        // Exceptions are best left in storage and processed
-        // on the next app launch
+        // Exceptions are left in storage and processed on the next app launch
     }
 
     void from_anr(const char *buffer, size_t buffsz) {
         to_storage("anr-", buffer, buffsz);
-        jni::on_application_not_responding(buffer);
+        // ANRs are left in storage and processed on the next app launch
     }
 
     /**
@@ -48,7 +46,7 @@ namespace serializer {
         std::ofstream os{storagePath.c_str(), std::ios::out | std::ios::binary};
 
         if (!os) {
-            _LOGE("serializer::to_storage error %d: %s", errno, strerror(errno));
+            _LOGE_POSIX("serializer::to_storage error");
         } else {
             os.write(payload, payload_size);
             os.flush();

--- a/agent-ndk/src/main/cpp/signal-utils.cpp
+++ b/agent-ndk/src/main/cpp/signal-utils.cpp
@@ -24,45 +24,48 @@ namespace sigutils {
         if (_stack->ss_sp != nullptr) {
             _stack->ss_size = stackSize;
             _stack->ss_flags = 0;
-            int rc = sigaltstack(_stack, 0);
-            if (rc != 0) {
-                _LOGE("Could not set the stack: %s", std::strerror(rc));
-                return false;
+            if (0 == sigaltstack(_stack, 0)) {
+                return true;
             }
+            _LOGE_POSIX("sigaltstack()");
         } else {
             _LOGE("Signal handler is disabled: could not alloc %zu-byte stack", stackSize);
-            return false;
         }
 
-        return true;
+        return false;
+
     }
 
     bool block_signal(int signo) {
         _LOGD("sigutils::block_signal(%d) on thread [%d]", signo, gettid());
 
         sigset_t sigmask;
-        sigemptyset(&sigmask);
-        sigaddset(&sigmask, signo);
-        if (pthread_sigmask(SIG_BLOCK, &sigmask, nullptr) != 0) {
-            _LOGE("Could not block signal [%d]: %s", signo, std::strerror(errno));
-            return false;
+        if (0 == sigemptyset(&sigmask)) {
+            if (0 == sigaddset(&sigmask, signo)) {
+                if (0 == pthread_sigmask(SIG_BLOCK, &sigmask, nullptr)) {
+                    return true;
+                }
+            }
         }
+        _LOGE("Could not block signal [%d]: %s", signo, std::strerror(errno));
 
-        return true;
+        return false;
     }
 
     bool unblock_signal(int signo) {
         _LOGD("sigutils::unblock_signal(%d) on thread [%d]", signo, gettid());
 
         sigset_t sigmask;
-        sigemptyset(&sigmask);
-        sigaddset(&sigmask, signo);
-        if (pthread_sigmask(SIG_UNBLOCK, &sigmask, nullptr) != 0) {
-            _LOGE("Could not unblock signal [%d]: %s", signo, std::strerror(errno));
-            return false;
+        if (0 == sigemptyset(&sigmask)) {
+            if (0 == sigaddset(&sigmask, signo)) {
+                if (0 == pthread_sigmask(SIG_UNBLOCK, &sigmask, nullptr)) {
+                    return true;
+                }
+            }
         }
+        _LOGE("Could not unblock signal [%d]: %s", signo, std::strerror(errno));
 
-        return true;
+        return false;
     }
 
     bool install_handler(int signo,
@@ -72,16 +75,16 @@ namespace sigutils {
               signo, sig_action, current_sig_action, gettid());
 
         struct sigaction handler = {};
-        sigemptyset(&handler.sa_mask);
-        handler.sa_flags = SA_SIGINFO | sa_flags;
-        handler.sa_sigaction = sig_action;
-
-        if (sigaction(signo, &handler, const_cast<struct sigaction *>(current_sig_action)) != 0) {
-            _LOGD("Could not install signal[%d] handler: %s.", signo, strerror(errno));
-            return false;
+        if (0 == sigemptyset(&handler.sa_mask)) {
+            handler.sa_flags = SA_SIGINFO | sa_flags;
+            handler.sa_sigaction = sig_action;
+            if (0 == sigaction(signo, &handler, const_cast<struct sigaction *>(current_sig_action))) {
+                return true;
+            }
         }
+        _LOGD("Could not install signal[%d] handler: %s.", signo, strerror(errno));
 
-        return true;
+        return false;
     }
 
     const char *get_subcode_description(int code, const char *default_description) {

--- a/agent-ndk/src/main/cpp/signal-utils.cpp
+++ b/agent-ndk/src/main/cpp/signal-utils.cpp
@@ -20,7 +20,7 @@ namespace sigutils {
         _LOGD("sigutils::set_sigstack (%zu) bytes to stack[%p]", stackSize, _stack);
 
         // caller must release this memory
-        _stack->ss_sp = calloc(1, stackSize);
+        _stack->ss_sp = malloc(stackSize);
         if (_stack->ss_sp != nullptr) {
             _stack->ss_size = stackSize;
             _stack->ss_flags = 0;

--- a/agent-ndk/src/main/cpp/unwinder.cpp
+++ b/agent-ndk/src/main/cpp/unwinder.cpp
@@ -48,7 +48,7 @@ static bool record_frame(uintptr_t ip, backtrace_state_t *state) {
 
     if (state->frame_cnt > 0) {
         // ignore null frames
-        if (ip == (uintptr_t) nullptr ) {
+        if (ip == (uintptr_t) nullptr) {
             _LOGW("record_frame[%zu]: Ignoring null ip", state->frame_cnt);
             state->skipped_frames++;
             return true;
@@ -58,8 +58,8 @@ static bool record_frame(uintptr_t ip, backtrace_state_t *state) {
         if (ip == state->frames[state->frame_cnt - 1]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat"
-            // _LOGD("record_frame[%zu]: ip[%zu] duplicate of frame[%lu]: ip[%zu]",
-            //      state->frame_cnt, ip, state->frame_cnt - 1, state->frames[state->frame_cnt - 1]);
+            _LOGD("record_frame[%zu]: ip[%zu] duplicate of frame[%lu]: ip[%zu]",
+                  state->frame_cnt, ip, state->frame_cnt - 1, state->frames[state->frame_cnt - 1]);
 #pragma clang diagnostic pop
             state->skipped_frames++;
             return true;
@@ -83,7 +83,7 @@ void transform_addr_to_stackframe(size_t index, uintptr_t address, stackframe_t 
     if (dladdr(reinterpret_cast<void *>(address), &info)) {
 
         if (info.dli_fname) {
-            std::strncpy(stackframe.so_path, info.dli_fname, sizeof(stackframe.so_path));
+            std::strncpy(stackframe.so_path, info.dli_fname, sizeof(stackframe.so_path) - 1);
         }
 
         if (info.dli_sname) {
@@ -93,7 +93,7 @@ void transform_addr_to_stackframe(size_t index, uintptr_t address, stackframe_t 
             if (demangled != nullptr && status == 0) {
                 symbol = demangled;
             }
-            std::strncpy(stackframe.sym_name, symbol, sizeof(stackframe.sym_name));
+            std::strncpy(stackframe.sym_name, symbol, sizeof(stackframe.sym_name) - 1);
         }
 
         // Relative addresses appear when code is compiled with
@@ -117,11 +117,11 @@ _Unwind_Reason_Code unwinder_cb(struct _Unwind_Context *ucontext, void *arg) {
 
     if (ip_before != 0) {
         // IP is before or after first not yet fully executed instruction
-        // _LOGD("unwinder_cb[%zu]: ip_before[%d]: address[%zu]", state->frame_cnt, ip_before, ip);
+        _LOGD("unwinder_cb[%zu]: ip_before[%d]: address[%zu]", state->frame_cnt, ip_before, ip);
     }
 
     if (ip == state->crash_ip) {
-        // _LOGV("unwinder_cb[%zu]: crash address[%zu]", state->frame_cnt, ip);
+        _LOGD("unwinder_cb[%zu]: crash address[%zu]", state->frame_cnt, ip);
         state->skipped_frames = state->frame_cnt;
         state->frame_cnt = 0;   // reset the index
     } else if (ip > 0) {

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ANRMonitor.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ANRMonitor.kt
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android.ndk
 
 import android.app.ActivityManager
+import android.app.ActivityManager.ProcessErrorStateInfo
 import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
@@ -13,7 +14,6 @@ import android.os.Looper
 import android.os.Process
 import com.newrelic.agent.android.agentdata.AgentDataController
 import com.newrelic.agent.android.stats.StatsEngine
-import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -21,9 +21,13 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * An secondary approach to detecting ANR conditions during runtime
- * from the JVM. The assumption here is a runnable task should pass
- * through the main looper (UI handler) within the default ANR latency period.
+ * An secondary approach to detecting main UI thread ANR conditions during runtime
+ * from the main looper. The assumption here is a runnable task should pass
+ * through the main looper (UI handler) within a reasonable ANR latency period.
+ *
+ * As of Android TIRAMISU, for regular apps this method will only return
+ * ProcessErrorStateInfo records for the processes running as the caller's uid,
+ * unless the caller has the permission Manifest.permission.DUMP.
  */
 open class ANRMonitor {
 
@@ -31,43 +35,52 @@ open class ANRMonitor {
     val handler = Handler(Looper.getMainLooper())
     val monitorThread = HandlerThread("NR-ANRMonitor")
     val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    var anrSampleCnt: AtomicInteger = AtomicInteger(ANR_SAMPLE_CNT)
     val anrMonitorRunner = Runnable {
         monitorThread.start()
 
         val runner = WaitableRunner()
+
         while (!Thread.interrupted()) {
 
             synchronized(runner) {
                 try {
                     if (!handler.post(runner)) {
-                        AgentNDK.log.debug("ANR monitor runner returns false")
-                        // post returns false on failure, usually because the
+                        // post() returns false on failure, usually because the
                         // looper processing the message queue is exiting
+                        AgentNDK.log.debug("Could not post the waitable runner to the main UI handler")
                         return@Runnable
                     }
 
+                    val tStart = System.currentTimeMillis()
                     runner.wait(ANR_TIMEOUT)
 
-                    if (!runner.signaled) {
-                        AgentNDK.log.debug("ANR monitor signaled false, ANR detected")
-                        createANRReport()
-                        runner.wait()
+                    if (runner.inANRState()) {
+                        if (0 == anrSampleCnt.decrementAndGet()) {
+                            AgentNDK.log.debug("ANR monitor is blocked, ANR detected")
+                            createANRReport()
+                            anrSampleCnt.set(ANR_SAMPLE_CNT)
+                        }
+                    } else {
+                        // park the monitor for the remaining period
+                        val tRemaining = ANR_TIMEOUT - (System.currentTimeMillis() - tStart)
+                        Thread.sleep(Math.max(0, tRemaining))
                     }
+
                 } catch (e: InterruptedException) {
-                    AgentNDK.log.error("ANR monitor exception caught: " + e.message)
+                    AgentNDK.log.error("ANR monitor caught $e")
+
                 } finally {
-                    runner.signaled = false
-                    runner.notifyAll()
-                    Thread.yield()
+                    runner.reset()
                 }
             }
         }
+
         monitorThread.quitSafely()
     }
 
     fun createANRReport(anrAsJson: String? = null) {
-        StatsEngine.get()
-            .inc(AgentNDK.Companion.MetricNames.SUPPORTABILITY_ANR_DETECTED)
+        StatsEngine.get().inc(AgentNDK.Companion.MetricNames.SUPPORTABILITY_ANR_DETECTED)
 
         // save the UI thread, aka the thread that is blocking
         val exception = NativeException(anrAsJson)
@@ -79,91 +92,77 @@ open class ANRMonitor {
         reportWithRetry(exception)
     }
 
-    internal fun isNativeTrace(stackTrace: Array<StackTraceElement>): Boolean {
-        if (!stackTrace.isEmpty()) {
-            return stackTrace[0].isNativeMethod
+    private fun hasNativeStackFrames(stackTrace: Array<StackTraceElement>?): Boolean {
+        stackTrace?.apply {
+            return find { it.isNativeMethod } != null
         }
         return false
     }
 
-    internal fun getProcessErrorStateOrNull(): ActivityManager.ProcessErrorStateInfo? {
-        val am = runCatching {
-            AgentNDK.getInstance().managedContext?.context!!.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        }.getOrNull()
-
-        try {
-            am?.processesInErrorState?.apply {
-                return firstOrNull { it.pid == Process.myPid() }
-            }
-        } catch (e: Exception) {
-            AgentNDK.log.error(e.toString())
-        }
-
-        return null
-    }
-
     internal fun reportWithRetry(exception: NativeException) {
         val handler = Handler(monitorThread.looper)
-        val retries = AtomicInteger(250)
-        val attributes: HashMap<String?, Any?> = HashMap<String?, Any?>()
+        val retries = AtomicInteger(10)
+        val attributes: HashMap<String?, Any?> = HashMap()
 
-        attributes.put(
-            AgentNDK.Companion.AnalyticsAttribute.APPLICATION_PLATFORM_ATTRIBUTE,
-            "native"
-        )
-        attributes.put(
-            AgentNDK.Companion.AnalyticsAttribute.APPLICATION_NOT_RESPONDING_ATTRIBUTE,
-            "true"
-        )
+        attributes[AgentNDK.Companion.AnalyticsAttribute.APPLICATION_PLATFORM_ATTRIBUTE] = "native"
+        attributes[AgentNDK.Companion.AnalyticsAttribute.APPLICATION_NOT_RESPONDING_ATTRIBUTE] = "true"
 
         exception.cause?.apply {
-            attributes.put("cause", this.message)
+            attributes["cause"] = this.message
         }
 
         exception.nativeStackTrace?.apply {
             crashedThread?.apply {
-                attributes.put("crashingThreadId", threadId)
+                attributes["crashingThreadId"] = threadId
             }
             threads.apply {
-                attributes.put("nativeThreads", this)
+                attributes["nativeThreads"] = this
             }
             exceptionMessage?.apply {
-                attributes.put("exceptionMessage", this)
+                attributes["exceptionMessage"] = this
             }
         }
 
         handler.post(
-            object : Runnable {
-                override fun run() {
-                    val anrDetails = getProcessErrorStateOrNull()
+                object : Runnable {
+                    override fun run() {
+                        getProcessErrorStateInfoOrNull()?.apply {
+                            attributes["pid"] = pid
+                            attributes["processName"] = processName
+                            attributes["shortMsg"] = shortMsg
+                            attributes["longMsg"] = longMsg
+                            attributes["stackTrace"] = stackTrace
+                            attributes["tag"] = tag
+                            when (condition) {
+                                ProcessErrorStateInfo.NOT_RESPONDING -> {
+                                    attributes["reason"] = 6
+                                    /** ApplicationExitInfo.REASON_ANR */
+                                }
 
-                    if (anrDetails != null) {
-                        attributes.put("pid", anrDetails.pid)
-                        attributes.put("uid", anrDetails.uid)
-                        attributes.put("processName", anrDetails.processName)
-                        attributes.put("shortMsg", anrDetails.shortMsg)
-                        attributes.put("longMsg", anrDetails.longMsg)
-                        attributes.put("stackTrace", anrDetails.stackTrace)
-                        attributes.put("tag", anrDetails.tag)
-                        attributes.put("condition", anrDetails.condition)
-                        retries.set(0)
-                    }
+                                ProcessErrorStateInfo.CRASHED -> {
+                                    attributes["reason"] = 4
+                                    /** ApplicationExitInfo.REASON_CRASH */
+                                }
+                            }
+                            retries.set(0)
+                        }
 
-                    when (retries.getAndDecrement()) {
-                        0 -> {
-                            AgentNDK.log.debug("ANR monitor notified. Posting ANR report")
-                            if (!AgentDataController.sendAgentData(exception, attributes)) {
-                                exception.printStackTrace()
+                        when (retries.getAndDecrement()) {
+                            0 -> {
+                                AgentNDK.log.debug(exception.toString())
+                                AgentNDK.log.debug("ANR monitor notified. Posting ANR report as handled exception[${exception.javaClass.simpleName}]")
+                                if (!AgentDataController.sendAgentData(exception, attributes)) {
+                                    exception.printStackTrace()
+                                }
+                                AgentNDK.log.debug("ANR report created")
+                            }
+
+                            else -> {
+                                handler.postDelayed(this, 500)
                             }
                         }
-
-                        else -> {
-                            handler.postDelayed(this, 50)
-                        }
                     }
-                }
-            }
-        )
+                })
     }
 
     fun startMonitor() {
@@ -178,6 +177,7 @@ open class ANRMonitor {
         future?.cancel(true)
         when (future?.isDone) {
             false -> future?.get()
+            else -> {}
         }
         future?.apply { future = null }
         AgentNDK.log.debug("ANR monitor stopped")
@@ -191,10 +191,14 @@ open class ANRMonitor {
     }
 
     companion object {
-        // The default Android ANR timeout is ~5 seconds.
-        // Setting timeout to 1 second captures code execution leading
-        // up to a reported ANR
-        val ANR_TIMEOUT = TimeUnit.MILLISECONDS.convert(5, TimeUnit.SECONDS)
+        // The default Android ANR timeout is about ~5 seconds, but use a generous value
+        val ANR_TIMEOUT = TimeUnit.MILLISECONDS.convert(6, TimeUnit.SECONDS)
+
+        // wait 2 consecutive ANRs before recording
+        const val ANR_SAMPLE_CNT = 2
+
+        // Running in a debugger?
+        // val inDebugger = (Debug.isDebuggerConnected() || Debug.waitingForDebugger())
 
         @Volatile
         var anrMonitor: ANRMonitor? = null
@@ -202,6 +206,23 @@ open class ANRMonitor {
         @JvmStatic
         fun getInstance() = anrMonitor ?: synchronized(this) {
             anrMonitor ?: ANRMonitor().also { anrMonitor = it }
+        }
+
+        @JvmStatic
+        fun getProcessErrorStateInfoOrNull(): ActivityManager.ProcessErrorStateInfo? {
+            val am = runCatching {
+                AgentNDK.getInstance().managedContext?.context!!.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            }.getOrNull()
+
+            try {
+                am?.processesInErrorState?.apply {
+                    return firstOrNull { it.pid == Process.myPid() }
+                }
+            } catch (e: Exception) {
+                AgentNDK.log.error(e.toString())
+            }
+
+            return null
         }
 
         /**
@@ -215,8 +236,30 @@ open class ANRMonitor {
             @Synchronized
             override fun run() {
                 signaled = true
+                notify()
+            }
+
+            @Synchronized
+            fun blocked(): Boolean {
+                return !signaled
+            }
+
+            @Synchronized
+            fun reset() {
+                signaled = false
                 notifyAll()
             }
+
+            fun inANRState(): Boolean {
+                if (blocked()) {
+                    getProcessErrorStateInfoOrNull()?.apply {
+                        return condition == ProcessErrorStateInfo.NOT_RESPONDING
+                    }
+                }
+
+                return false
+            }
+
         }
     }
 }

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
@@ -40,8 +40,7 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
             companion object {
                 const val SUPPORTABILITY_NATIVE_ROOT = "Supportability/AgentHealth/NativeReporting"
                 const val SUPPORTABILITY_NATIVE_CRASH = "$SUPPORTABILITY_NATIVE_ROOT/Crash"
-                const val SUPPORTABILITY_NATIVE_LOAD_ERR =
-                    "$SUPPORTABILITY_NATIVE_ROOT/Error/LoadLibrary"
+                const val SUPPORTABILITY_NATIVE_LOAD_ERR = "$SUPPORTABILITY_NATIVE_ROOT/Error/LoadLibrary"
                 const val SUPPORTABILITY_ANR_DETECTED = "$SUPPORTABILITY_NATIVE_ROOT/ANR/Detected"
             }
         }
@@ -83,15 +82,15 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
 
     fun start(): Boolean {
         if (managedContext?.anrMonitor == true) {
-            Log.d("AgentNDK", "Starting ANR monitor")
             ANRMonitor.getInstance().startMonitor()
+            Log.d("AgentNDK", "Main thread ANR monitor started")
         }
 
         return nativeStart(managedContext!!)
     }
 
     fun stop() {
-        managedContext?.anrMonitor.let {
+        if (managedContext?.anrMonitor == true) {
             ANRMonitor.getInstance().stopMonitor()
         }
         nativeStop()
@@ -116,8 +115,8 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
 
                             val expirationTimeMs: Long = (System.currentTimeMillis() -
                                     TimeUnit.MILLISECONDS.convert(
-                                        managedContext.expirationPeriod,
-                                        TimeUnit.SECONDS
+                                            managedContext.expirationPeriod,
+                                            TimeUnit.SECONDS
                                     ))
 
                             if (report.exists() && (report.lastModified() < expirationTimeMs)) {

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ManagedContext.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/ManagedContext.kt
@@ -21,15 +21,15 @@ class ManagedContext(val context: Context? = null) {
     var expirationPeriod = DEFAULT_TTL
 
     fun getNativeReportsDir(rootDir: File?): File {
-        return File("${rootDir?.absolutePath}/newrelic/reports")
+        return File("${rootDir?.absolutePath}/newrelic/nativeReporting")
     }
 
     fun getNativeLibraryDir(context: Context?): File {
-        val packageName = context?.packageName
-        val packageManager = context?.packageManager
-        context?.apply {
+        val packageName = context!!.packageName as String
+        val packageManager = context.packageManager
+        context.apply {
             val ainfo: ApplicationInfo? = packageManager?.getApplicationInfo(
-                packageName, PackageManager.GET_SHARED_LIBRARY_FILES
+                    packageName, PackageManager.GET_SHARED_LIBRARY_FILES
             )
             ainfo?.nativeLibraryDir?.apply {
                 return File(this)

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeStackFrame.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeStackFrame.kt
@@ -43,13 +43,13 @@ class NativeStackFrame(
         return this
     }
 
-    fun fromJson(stackFrameAsStr: String?): NativeStackFrame {
+    fun fromJson(stackFrameAsStr: String): NativeStackFrame {
         return fromJson(JSONObject(stackFrameAsStr))
     }
 
     companion object {
         fun allFrames(allFrames: JSONArray?): MutableList<StackTraceElement> {
-            var stackFrames: MutableList<StackTraceElement> = mutableListOf<StackTraceElement>()
+            val stackFrames: MutableList<StackTraceElement> = mutableListOf()
 
             allFrames?.apply {
                 for (i in 0 until length()) {
@@ -74,7 +74,7 @@ class NativeStackFrame(
         }
 
         fun allNativeFrames(allFrames: JSONArray?): MutableList<NativeStackFrame> {
-            var stackFrames: MutableList<NativeStackFrame> = mutableListOf<NativeStackFrame>()
+            val stackFrames: MutableList<NativeStackFrame> = mutableListOf()
 
             allFrames?.apply {
                 for (i in 0 until length()) {

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeStackTrace.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeStackTrace.kt
@@ -18,22 +18,22 @@ class NativeStackTrace(stackTraceAsString: String? = null) {
         }
     }
 
-    private fun transformNativeStackTrace(stackTraceAsString: String?): NativeStackTrace {
+    private fun transformNativeStackTrace(stackTraceAsString: String): NativeStackTrace {
         return transformNativeStackTrace(JSONObject(stackTraceAsString))
     }
 
     private fun transformNativeStackTrace(jsonObj: JSONObject): NativeStackTrace {
         try {
             jsonObj.apply {
-                getJSONObject("backtrace")?.apply {
+                getJSONObject("backtrace").apply {
                     try {
-                        getJSONObject("exception")?.apply {
+                        getJSONObject("exception").apply {
                             val cause = optString("cause", "")
-                            exceptionMessage = "${getString("name")}: ${cause}"
-                            getJSONObject("signalInfo")?.apply {
+                            exceptionMessage = "${getString("name")}: $cause"
+                            getJSONObject("signalInfo").apply {
                                 exceptionMessage =
                                     "${getString("signalName")} " +
-                                            "(code ${getInt("signalCode")}) ${cause} " +
+                                            "(code ${getInt("signalCode")}) $cause " +
                                             "at 0x${getLong("faultAddress").toString(16)}"
                             }
                         }
@@ -42,11 +42,11 @@ class NativeStackTrace(stackTraceAsString: String? = null) {
                     }
 
                     try {
-                        getJSONArray("threads")?.apply {
+                        getJSONArray("threads").apply {
                             threads = NativeThreadInfo.allThreads(this)
-                            threads.find() {
+                            threads.find {
                                 it.isCrashingThread()
-                            }?.apply {
+                            }.apply {
                                 crashedThread = this
                             }
                         }

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeThreadInfo.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/NativeThreadInfo.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
 
 class NativeThreadInfo(nativeException: NativeException?) : ThreadInfo(nativeException) {
 
-    constructor() : this(NativeException()) {}
+    constructor() : this(NativeException())
 
     constructor(threadInfoAsJson: String?) : this() {
         fromJson(threadInfoAsJson)
@@ -35,24 +35,24 @@ class NativeThreadInfo(nativeException: NativeException?) : ThreadInfo(nativeExc
     }
 
     fun fromJson(threadInfoAsJsonStr: String?): NativeThreadInfo {
-        return fromJsonObject(JSONObject(threadInfoAsJsonStr))
+        return fromJsonObject(threadInfoAsJsonStr?.let { JSONObject(it) })
     }
 
-    fun stackTraceFromJson(allFrames: JSONArray?): Array<StackTraceElement?>? {
+    private fun stackTraceFromJson(allFrames: JSONArray?): Array<StackTraceElement?> {
         var stack = arrayOfNulls<StackTraceElement>(0)
 
         try {
             allFrames?.apply {
                 val ukn = "<unknown>"
-                stack = arrayOfNulls<StackTraceElement>(allFrames.length())
+                stack = arrayOfNulls(allFrames.length())
                 for (i in 0 until length()) {
                     if (!isNull(i)) {
                         try {
                             val frame = get(i) as JSONObject
                             val nativeFrame = NativeStackFrame().fromJson(frame)
-                            stack.set(i, nativeFrame.asStackTraceElement());
+                            stack[i] = nativeFrame.asStackTraceElement()
                         } catch (e: Exception) {
-                            stack.set(i, StackTraceElement(ukn, ukn, ukn, -2));
+                            stack[i] = StackTraceElement(ukn, ukn, ukn, -2)
                         }
                     }
                 }
@@ -65,7 +65,7 @@ class NativeThreadInfo(nativeException: NativeException?) : ThreadInfo(nativeExc
     }
 
     fun isCrashingThread(): Boolean {
-        return crashed;
+        return crashed
     }
 
     fun getStackTrace(): Array<StackTraceElement?>? {

--- a/agent-ndk/src/test/java/com/newrelic/agent/android/ndk/ManagedContextTest.kt
+++ b/agent-ndk/src/test/java/com/newrelic/agent/android/ndk/ManagedContextTest.kt
@@ -45,7 +45,7 @@ class ManagedContextTest : TestCase(), AgentNDKListener {
 
     @Test
     fun testGetReportDirectory() {
-        val target = File("${context?.cacheDir?.absolutePath}/newrelic/reports")
+        val target = File("${context?.cacheDir?.absolutePath}/newrelic/nativeReporting")
         Assert.assertEquals(target.absolutePath, managedContext?.reportsDir?.absolutePath)
     }
 

--- a/agent-ndk/src/test/java/com/newrelic/agent/android/ndk/NativeThreadInfoTest.kt
+++ b/agent-ndk/src/test/java/com/newrelic/agent/android/ndk/NativeThreadInfoTest.kt
@@ -17,7 +17,7 @@ class NativeThreadInfoLegacyTest : TestCase() {
     }
 
     fun testFromJsonObject() {
-        nativeThreadInfo = NativeThreadInfo().fromJsonObject(JSONObject(threadInfo))
+        nativeThreadInfo = NativeThreadInfo().fromJsonObject(threadInfo?.let { JSONObject(it) })
         Assert.assertTrue(nativeThreadInfo.threadId > 0)
     }
 
@@ -27,7 +27,7 @@ class NativeThreadInfoLegacyTest : TestCase() {
     }
 
     fun testAllThreads() {
-        val threads = JSONObject(backtrace).getJSONObject("backtrace").getJSONArray("threads")
+        val threads = backtrace?.let { JSONObject(it).getJSONObject("backtrace").getJSONArray("threads") }
         val allThreads = NativeThreadInfo.allThreads(threads)
         Assert.assertTrue(allThreads.size > 1)
     }

--- a/buildconfig.gradle
+++ b/buildconfig.gradle
@@ -9,9 +9,9 @@ buildscript {
 
         newrelic = [
                 version: hasOptional('newrelic.version', '+'),
-                agent: [
-                        version       : hasOptional('newrelic.agent.version', '+'),
-                        snapshot      : hasOptional('newrelic.agent.snapshot', null),
+                agent  : [
+                        version : hasOptional('newrelic.agent.version', '+'),
+                        snapshot: hasOptional('newrelic.agent.snapshot', null),
                 ]
         ]
 
@@ -22,34 +22,34 @@ buildscript {
         ]
 
         versions = [
-                test  : [
+                test     : [
                         junit       : '4.12',
                         mockitoCore : '2.28.2',
                         robolectric : '4.6.+',
                         androidxCore: '1.4.+',
-                        owasp: '8.1.2',
-                        jacoco: '0.8.4',
+                        owasp       : '8.1.2',
+                        jacoco      : '0.8.4',
                 ],
-                kotlin: [
+                kotlin   : [
                         plugin : "1.6.0",
                         ktx    : "1.3.2",
                         mockito: "3.2.0"
                 ],
-                agp   : [
+                agp      : [
                         // https://developer.android.com/studio/releases/platforms
                         plugin    : hasOptional('newrelic.agp.version', '4.1.+'),
-                        minSdk    : 24,         // Android 7.0
-                        compileSdk: 28,         // Android 8.1
-                        targetSdk : 28,         // Android 8.1
+                        minSdk    : 24, // Android 7
+                        compileSdk: 30, // Android 11
+                        targetSdk : 30, // Android 11
                         buildTools: '29.0.2',
                         ndk       : '21.4.7075529',
                         cmake     : '3.18.1'
                 ],
-                libraries  : [
-                        rootbeer       : '0.1.0',
+                libraries: [
+                        rootbeer: '0.1.0',
                 ],
-                java  : [
-                        nexus       : '1.1.0',
+                java     : [
+                        nexus: '1.1.0',
                 ],
         ]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 # Version of the SDK to be built and deployed
-newrelic.version=1.1.0
+newrelic.version=1.1.1
 newrelic.version.build=SNAPSHOT
 newrelic.agp.version=7.+
 newrelic.agent.version=+

--- a/samples/android-test-native/src/legacy/java/com/newrelic/agent/android/ndk/samples/NewRelicAgent.kt
+++ b/samples/android-test-native/src/legacy/java/com/newrelic/agent/android/ndk/samples/NewRelicAgent.kt
@@ -20,8 +20,10 @@ class NewRelicAgent(val activity: Activity) {
 
     fun onCreate() {
         NewRelic.enableFeature(FeatureFlag.NativeReporting)
+        NewRelic.disableFeature(FeatureFlag.ApplicationExitReporting)
+        NewRelic.disableFeature(FeatureFlag.LogReporting)
 
-        legacyAgent = NewRelic.withApplicationToken("<app-token>")
+        legacyAgent = NewRelic.withApplicationToken("<APP-TOKEN>")
             .withLogLevel(AgentLog.DEBUG)
             .withApplicationBuild("Legacy Native agent")
 

--- a/samples/android-test-native/src/main/cpp/procfs.h
+++ b/samples/android-test-native/src/main/cpp/procfs.h
@@ -14,8 +14,10 @@ static const char *TAG = "newrelic";
 #define  _LOGW(...)  __android_log_print(ANDROID_LOG_WARN,    TAG, __VA_ARGS__)
 #define  _LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,   TAG, __VA_ARGS__)
 #define  _LOGI(...)  __android_log_print(ANDROID_LOG_INFO,    TAG, __VA_ARGS__)
-#define  _LOGV(...)  __android_log_print(ANDROID_LOG_VERBOSE, TAG, __VA_ARGS__)
 
+#include <errno.h>
+#include <string.h>
+#define  _LOGE_POSIX(msg)  __android_log_print(ANDROID_LOG_INFO, TAG, "%s: %s (errno %d - %s)", __PRETTY_FUNCTION__, msg, errno, std::strerror(errno))
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/android-test-native/src/main/java/com/newrelic/agent/android/ndk/samples/MainActivity.kt
+++ b/samples/android-test-native/src/main/java/com/newrelic/agent/android/ndk/samples/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity(), AgentNDKListener {
             btnANR.text = "Sleeping..."    // needs some user input
             btnANR.setPressed(true);
             btnANR.invalidate();
-            Thread.sleep(8000)
+            Thread.sleep(10000)
             btnANR.text = getString(R.string.anr)
         }
     }
@@ -105,7 +105,7 @@ class MainActivity : AppCompatActivity(), AgentNDKListener {
         contentProvider.query(
             CheeseyContentProvider.CONTENT_URI,
             null, null, null, null
-        ).apply {
+        )?.apply {
             val stock = StringBuilder("CONTENT_URI: " + contentType + "\n");
             if (moveToFirst()) {
                 while (!isAfterLast()) {


### PR DESCRIPTION
[NR-274896] fix:plug leaks in main UI ANR monitor
ANRMonitor will now only report if the waitable runner is not signaled AND an ActivityManager ProcessErrorStateInfo record for this pid shows a condition of NOT_RESPONDING.

* ANRMonitor now samples every 3 triggered conditions to avoid overreporting.
* renamed reports directory to `newrelic/nativeReporting` (to make feature, like others)

With the addition of the ApplicationExitInfo feature, the NDK main thread monitor (ANRMonitor) will be rarely used. It's now slowed down quite a bit (sleeps after waitable runner is signaled, rather than  immediately retesting). Triggering these conditions will now be much more seldom, but when captured  the ANR report will now any contain ProcessErrorStateInfo data offered by the Android runtime

[NR-274896] chore: clean up POSIX api call checking
* verify each call with logging on failure
* check  the length of buffers when using std::strn* functions

[NR-274896] chore: update Android SDK levels
To match Android agent levels




[NR-274896]: https://new-relic.atlassian.net/browse/NR-274896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-274896]: https://new-relic.atlassian.net/browse/NR-274896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-274896]: https://new-relic.atlassian.net/browse/NR-274896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ