### PR TITLE
Revert AgentNDK.stop() method signature change

### DIFF
--- a/agent-ndk/src/main/cpp/agent-ndk.cpp
+++ b/agent-ndk/src/main/cpp/agent-ndk.cpp
@@ -88,7 +88,7 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStart(JNIEnv *env, jobject th
 }
 
 extern "C"
-JNIEXPORT jboolean JNICALL
+JNIEXPORT void JNICALL
 Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStop(JNIEnv *env, jobject thiz) {
     (void) env;
     (void) thiz;
@@ -98,8 +98,6 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStop(JNIEnv *env, jobject thi
         anr_handler_shutdown();
     }
     terminate_handler_shutdown();
-
-    return true;
 }
 
 extern "C"

--- a/agent-ndk/src/main/cpp/include/agent-ndk.h
+++ b/agent-ndk/src/main/cpp/include/agent-ndk.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #ifndef AGENT_VERSION
-#define AGENT_VERSION "1.1.1" // Update it Every Release
+#define AGENT_VERSION "1.1.2" // Update it Every Release
 #endif  // !AGENT_VERSION
 
 static const char *TAG = "com.newrelic.android";

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
@@ -21,7 +21,7 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
      * API methods
      **/
     external fun nativeStart(context: ManagedContext? = null): Boolean
-    external fun nativeStop(): Boolean
+    external fun nativeStop()
     external fun nativeSetContext(context: ManagedContext)
 
     external fun crashNow(cause: String? = "This is a demonstration native crash courtesy of New Relic")
@@ -51,7 +51,7 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
         var log: AgentLog = ConsoleAgentLog()
 
         @Volatile
-        var agentNdk: AgentNDK? = null
+        private var agentNdk: AgentNDK? = null
 
         @JvmStatic
         fun loadAgent(): Boolean {
@@ -89,12 +89,11 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
         return nativeStart(managedContext!!)
     }
 
-    fun stop(): Boolean {
+    fun stop() {
         if (managedContext?.anrMonitor == true) {
             ANRMonitor.getInstance().stopMonitor()
         }
-
-        return nativeStop()
+        nativeStop()
     }
 
     fun flushPendingReports() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 # Version of the SDK to be built and deployed
-newrelic.version=1.1.1
+newrelic.version=1.1.2
 newrelic.version.build=SNAPSHOT
 newrelic.agp.version=7.+
 newrelic.agent.version=+


### PR DESCRIPTION
Reverts API change that lead to runtime crashes in the agent when shutting down