### PR TITLE
Android supports 16KB page size

### DIFF
--- a/agent-ndk/src/main/cpp/CMakeLists.txt
+++ b/agent-ndk/src/main/cpp/CMakeLists.txt
@@ -37,6 +37,11 @@ target_include_directories(agent-ndk PUBLIC include)
 target_include_directories(agent-ndk PRIVATE .)
 target_link_libraries(agent-ndk ${log-lib})
 
+# 16 KB page size compatibility
+target_link_options(agent-ndk PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(agent-ndk PRIVATE "-Wl,-z,common-page-size=16384")
+
+
 ##
 # For tests and debugging
 ##

--- a/buildconfig.gradle
+++ b/buildconfig.gradle
@@ -46,7 +46,7 @@ buildscript {
                         cmake     : '3.22.1'
                 ],
                 libraries: [
-                        rootbeer: '0.1.0',
+                        rootbeer: '0.1.1',
                 ],
                 java     : [
                         nexus: '1.1.0',


### PR DESCRIPTION
Ensure Android arm64-v8a and x86_64 Android supports 16KB page size

https://developer.android.com/guide/practices/page-sizes
https://github.com/newrelic/newrelic-flutter-agent/issues/147