### PR TITLE
Potential fix for code scanning alert no. 1: Implicitly exported Android component

### DIFF
--- a/samples/android-test-native/src/main/AndroidManifest.xml
+++ b/samples/android-test-native/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         </service>
 
         <receiver android:name=".service.AlarmProvider$AlarmReceiver"
-            android:enabled="true">
+            android:enabled="true"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"></action>
             </intent-filter>


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/1](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/1)

To fix this issue, explicitly set `android:exported` on the flagged component declaration in the manifest.

Best fix without changing intended functionality:
- In `samples/android-test-native/src/main/AndroidManifest.xml`, update the `<receiver android:name=".service.AlarmProvider$AlarmReceiver" ...>` block to include `android:exported="true"`.
- Keep existing `intent-filter` and `android:enabled` unchanged.
- No code changes, imports, methods, or definitions are needed—only manifest attribute addition.

This preserves current behavior (receiver remains available for BOOT_COMPLETED broadcast) while removing implicit export ambiguity and satisfying CodeQL and modern Android manifest requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
