### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/2](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/repolinter.yml` so `GITHUB_TOKEN` is least-privileged and stable regardless of repo/org defaults.

Best fix here (without changing behavior): define permissions at the workflow root, since there is only one job. Grant:
- `contents: read` (needed for checkout/repo reads),
- `issues: write` (needed because `output_type: issue` indicates the action may create/update issues).

Edit region: directly after the `on:` declaration and before `jobs:`.

No imports, methods, or dependencies are needed—this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
