### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,8 @@
 name: Generate Codecov Report
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ develop, main ]


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/3](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/codecov.yml` at the workflow root so it applies to all jobs by default.  
For this workflow, the minimal safe baseline is:

- `contents: read` (required for repository checkout/read access)

No additional write scopes are clearly required by the shown steps. This preserves existing functionality while constraining token privileges.

Edit region: near the top of `.github/workflows/codecov.yml`, directly after `name:` and before `on:`.

No imports, methods, or dependency changes are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
