### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ develop, main ]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/4](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/4)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best single change (without altering behavior) is to set workflow-level permissions to:

- `contents: read`

This covers checkout and typical read-only CI operations. Since this workflow builds/tests and does not appear to write issues, PRs, releases, or packages, no write scopes are needed.

**File to edit:** `.github/workflows/android.yml`  
**Region:** near the top-level keys (`name`, `on`, `jobs`)  
**Change:** insert `permissions:` between `on` and `jobs` (or after `name`), with `contents: read`.

No imports, methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
