### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "release/**"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/5](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/5)

Add an explicit `permissions` block to the workflow (or the `release` job) with the minimum required scopes.  
For this workflow, `actions/create-release@v1` needs to create a release, which requires `contents: write`. No other elevated scopes are needed based on the shown steps. `actions/checkout` and changelog generation are compatible with `contents` access as well.

Best fix without changing functionality: add a root-level `permissions` block right after the `on` trigger (before `jobs`) so all jobs inherit it. Set:
- `contents: write`

File to change:
- `.github/workflows/create_release.yml` (insert permissions between lines 7 and 8 in the provided snippet).

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
