### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonatypeDeployment.yml
+++ b/.github/workflows/sonatypeDeployment.yml
@@ -10,6 +10,9 @@ on:
         default: '1.+'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   assemble_project:
     name: Assemble project


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/6](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/sonatypeDeployment.yml` to constrain `GITHUB_TOKEN` for all jobs in this workflow.  
Best single fix without changing behavior: set:

- `contents: read` (sufficient for checkout/read repo content)

Place this block at workflow root level (after `on:` section and before `jobs:`), so both `assemble_project` and `publish_release` inherit it. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
