### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonatypeDeployment.yml
+++ b/.github/workflows/sonatypeDeployment.yml
@@ -10,6 +10,9 @@ on:
         default: '1.+'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   assemble_project:
     name: Assemble project


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/7](https://github.com/newrelic/newrelic-ndk-agent/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root so all jobs inherit a minimal token scope.  
For this workflow, a safe minimal baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only repository access while preventing unnecessary write privileges. Since no step in the provided snippet requires `GITHUB_TOKEN` write scopes, this does not change intended functionality.

**Where to change**: `.github/workflows/sonatypeDeployment.yml`, immediately after the `on:` section (before `jobs:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
