### PR TITLE
fix(NR-578121): restore void return for AgentNDK.stop()/nativeStop()

### DIFF
--- a/agent-ndk/src/main/cpp/agent-ndk.cpp
+++ b/agent-ndk/src/main/cpp/agent-ndk.cpp
@@ -88,7 +88,7 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStart(JNIEnv *env, jobject th
 }
 
 extern "C"
-JNIEXPORT jboolean JNICALL
+JNIEXPORT void JNICALL
 Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStop(JNIEnv *env, jobject thiz) {
     (void) env;
     (void) thiz;
@@ -98,8 +98,6 @@ Java_com_newrelic_agent_android_ndk_AgentNDK_nativeStop(JNIEnv *env, jobject thi
         anr_handler_shutdown();
     }
     terminate_handler_shutdown();
-
-    return true;
 }
 
 extern "C"

--- a/agent-ndk/src/main/cpp/include/agent-ndk.h
+++ b/agent-ndk/src/main/cpp/include/agent-ndk.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #ifndef AGENT_VERSION
-#define AGENT_VERSION "1.1.3" // Update it Every Release
+#define AGENT_VERSION "1.1.5" // Update it Every Release
 #endif  // !AGENT_VERSION
 
 static const char *TAG = "com.newrelic.android";

--- a/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
+++ b/agent-ndk/src/main/java/com/newrelic/agent/android/ndk/AgentNDK.kt
@@ -21,7 +21,7 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
      * API methods
      **/
     external fun nativeStart(context: ManagedContext? = null): Boolean
-    external fun nativeStop() : Boolean
+    external fun nativeStop()
     external fun nativeSetContext(context: ManagedContext)
 
     external fun crashNow(cause: String? = "This is a demonstration native crash courtesy of New Relic")
@@ -90,11 +90,11 @@ open class AgentNDK(val managedContext: ManagedContext? = ManagedContext()) {
         return nativeStart(managedContext!!)
     }
 
-    fun stop() : Boolean{
+    fun stop() {
         if (managedContext?.anrMonitor == true) {
             ANRMonitor.getInstance().stopMonitor()
         }
-        return nativeStop()
+        nativeStop()
     }
 
     fun flushPendingReports() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 # Version of the SDK to be built and deployed
-newrelic.version=1.1.4
+newrelic.version=1.1.5
 newrelic.version.build=SNAPSHOT
 newrelic.agp.version=7.+
 newrelic.agent.version=+


### PR DESCRIPTION
## Jira
NR-578121

## What & Why
agent-ndk 1.1.4 broke binary compatibility by changing `AgentNDK.stop()` / `nativeStop()` from `void` to `boolean`. This crashes apps on backgrounding:

```
FATAL EXCEPTION: NR_AppStateMon-1
java.lang.NoSuchMethodError: No virtual method stop()V in class
  Lcom/newrelic/agent/android/ndk/AgentNDK;
    at com.newrelic.agent.android.ndk.NativeReporting.stop(NativeReporting.java:110)
    at com.newrelic.agent.android.ndk.NativeReporting.shutdown(NativeReporting.java:53)
    at com.newrelic.agent.android.AndroidAgentImpl.stop(AndroidAgentImpl.java:659)
    at com.newrelic.agent.android.AndroidAgentImpl.applicationBackgrounded(AndroidAgentImpl.java:945)
```

| agent-ndk | `stop()` | JVM descriptor |
|---|---|---|
| 1.1.3 | `void`    | `stop()V` |
| 1.1.4 | `boolean` | `stop()Z` |

The JVM resolves a virtual method by name **and full descriptor including return type**, so `stop()V` and `stop()Z` are distinct methods. The android-agent's `NativeReporting` compiles against agent-ndk as a `compileOnly` dependency; host apps resolve the runtime version independently, typically via a dynamic `1.+` range. An agent built against 1.1.3 emits `INVOKEVIRTUAL stop()V`, but resolves 1.1.4 at runtime (only `stop()Z`) → `NoSuchMethodError`.

This signature has flip-flopped before (NR-271330 void→boolean, NR-298871 boolean→void, NR-373723 void→boolean), reintroducing this exact crash each time it goes to boolean. A return-type change is source-compatible but never binary-compatible.

## The fix
Restore `void` for `stop()`/`nativeStop()` (Kotlin + JNI), matching the descriptor already-shipped agents are linked against, so this release **repairs deployed apps in place** via the `1.+` range. Bumped to **1.1.5** so Maven `1.+` supersedes the broken 1.1.4 — republishing `void` as ≤1.1.4 would not win resolution. The boolean return was unused by all known consumers (android-agent ignores it; no internal or test reader). Also corrects the stale `AGENT_VERSION` in `agent-ndk.h` (was `1.1.3`).

The signature changes are the exact inverse of c3a8cc8 (NR-373723), restoring the verified pre-regression blobs.

## Callouts
- Native `nativeStop()` no longer returns a value — there are no callers of the return in this repo or the android-agent.
- Complementary agent-side hardening: newrelic/newrelic-android-agent PR #565 widens `NativeReporting.stop()`'s catch to `LinkageError` so the agent never crashes on this class of ABI drift regardless of which ndk version resolves. That is a forward fix; this PR is the retroactive one.
- Follow-up worth filing: the android-agent should pin agent-ndk to an exact tested version instead of `1.+` so the compiled descriptor and resolved runtime class cannot diverge.

## Test plan
- Native toolchain build of the AAR; confirm `javap -p` on the published `AgentNDK` shows `public final void stop()` (descriptor `stop()V`).
- Smoke: an app using a released android-agent (compiled to `stop()V`) + this agent-ndk no longer throws `NoSuchMethodError` when backgrounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)